### PR TITLE
Replace deprecated methods

### DIFF
--- a/src/MediaQuery.svelte
+++ b/src/MediaQuery.svelte
@@ -24,14 +24,14 @@
 
     function addNewListener(query) {
         mql = window.matchMedia(query);
-        mqlListener = v => matches = v.matches;
-        mql.addListener(mqlListener);
+        mqlListener = (v) => (matches = v.matches);
+        mql.addEventListener("event", mqlListener);
         matches = mql.matches;
     }
 
     function removeActiveListener() {
         if (mql && mqlListener) {
-            mql.removeListener(mqlListener);
+            mql.removeEventListener("event", mqlListener);
         }
     }
 </script>


### PR DESCRIPTION
Thanks for creating this library!

I noticed there were deprecation warnings for some methods used, so I made a quick patch to use the modern API:s.

Tested locally with [this MediaQuery](https://github.com/Greenheart/greenheart.github.io/blob/2021/src/components/TechStack.svelte#L85-L111) and it works just as expected.